### PR TITLE
Add more behavior tree libraries

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,7 @@ For an introduction to robot deliberation, refer to [Ingrand and Ghallab (2017)]
 
 ### Behavior Abstractions
 - [BehaviorTree.ROS2](https://github.com/BehaviorTree/BehaviorTree.ROS2) - ROS 2 wrapper for [BehaviorTree.CPP](https://github.com/BehaviorTree/BehaviorTree.CPP), an implementation of behavior trees in C++.
-- [BT Studio](https://github.com/JdeRobot/bt-studio) - A web IDE for development of behavior trees. Uses [PyTrees](https://github.com/splintered-reality/py_trees) internally, but uses the XML representation in [BehaviorTree.CPP](https://github.com/BehaviorTree/BehaviorTree.CPP).
+- [BT Studio](https://github.com/JdeRobot/bt-studio) - A web IDE for development of behavior trees. Uses PyTrees internally, but leverages the XML representation in BehaviorTree.CPP to define trees.
 - [FlexBE](https://github.com/FlexBE/flexbe_behavior_engine) - State machine implementation with web-based GUI.
 - [PyTrees ROS](https://github.com/splintered-reality/py_trees_ros) - ROS 2 wrapper for the [PyTrees](https://github.com/splintered-reality/py_trees) behavior tree library.
 - [ros_bt_py](https://github.com/fzi-forschungszentrum-informatik/ros2_ros_bt_py) - ROS 2 and Python based library for behavior trees, with a ReactJS based web GUI.

--- a/readme.md
+++ b/readme.md
@@ -31,8 +31,8 @@ For an introduction to robot deliberation, refer to [Ingrand and Ghallab (2017)]
 - [UP4ROS2](https://github.com/aiplan4eu/UP4ROS2) - ROS 2 wrapper for the [AIPlan4EU Unified Planning library](https://github.com/aiplan4eu/unified-planning).
 
 ### Behavior Abstractions
-- [BehaviorTree.CPP](https://github.com/BehaviorTree/BehaviorTree.ROS) - Implementation of behavior trees in C++.
-- [BT Studio](https://github.com/JdeRobot/bt-studio) - A web IDE for development of behavior trees. Uses [PyTrees](https://github.com/splintered-reality/py_trees) internally, but uses the XML representation in [BehaviorTree.CPP](https://github.com/BehaviorTree/BehaviorTree.ROS).
+- [BehaviorTree.ROS2](https://github.com/BehaviorTree/BehaviorTree.ROS2) - ROS 2 wrapper for [BehaviorTree.CPP](https://github.com/BehaviorTree/BehaviorTree.CPP), an implementation of behavior trees in C++.
+- [BT Studio](https://github.com/JdeRobot/bt-studio) - A web IDE for development of behavior trees. Uses [PyTrees](https://github.com/splintered-reality/py_trees) internally, but uses the XML representation in [BehaviorTree.CPP](https://github.com/BehaviorTree/BehaviorTree.CPP).
 - [FlexBE](https://github.com/FlexBE/flexbe_behavior_engine) - State machine implementation with web-based GUI.
 - [PyTrees ROS](https://github.com/splintered-reality/py_trees_ros) - ROS 2 wrapper for the [PyTrees](https://github.com/splintered-reality/py_trees) behavior tree library.
 - [ros_bt_py](https://github.com/fzi-forschungszentrum-informatik/ros2_ros_bt_py) - ROS 2 and Python based library for behavior trees, with a ReactJS based web GUI.

--- a/readme.md
+++ b/readme.md
@@ -32,8 +32,10 @@ For an introduction to robot deliberation, refer to [Ingrand and Ghallab (2017)]
 
 ### Behavior Abstractions
 - [BehaviorTree.CPP](https://github.com/BehaviorTree/BehaviorTree.ROS) - Implementation of behavior trees in C++.
+- [BT Studio](https://github.com/JdeRobot/bt-studio) - A web IDE for development of behavior trees. Uses [PyTrees](https://github.com/splintered-reality/py_trees) internally, but uses the XML representation in [BehaviorTree.CPP](https://github.com/BehaviorTree/BehaviorTree.ROS).
 - [FlexBE](https://github.com/FlexBE/flexbe_behavior_engine) - State machine implementation with web-based GUI.
 - [PyTrees ROS](https://github.com/splintered-reality/py_trees_ros) - ROS 2 wrapper for the [PyTrees](https://github.com/splintered-reality/py_trees) behavior tree library.
+- [ros_bt_py](https://github.com/fzi-forschungszentrum-informatik/ros2_ros_bt_py) - ROS 2 and Python based library for behavior trees, with a ReactJS based web GUI.
 - [SMACC2](https://github.com/robosoft-ai/SMACC2) - State machine implementation in C++.
 - [YASMIN](https://github.com/uleroboticsgroup/yasmin) - State machine implementation for C++ and Python.
 


### PR DESCRIPTION
I was doing some homework for the next community group meeting and found that `ros_bt_py` and `bt_studio` were also not present!

Also fixed up some BT.CPP material for consistency.